### PR TITLE
chore: enable corepack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ https://unjs.io
 ## Development
 
 - Clone repository
+- Enable corepack with `corepack enable pnpm`
 - Install dependencies with `pnpm install`
 - Start development server with `pnpm dev`

--- a/package.json
+++ b/package.json
@@ -8,5 +8,6 @@
   "devDependencies": {
     "nuxt": "^3.0.0",
     "sass": "^1.56.1"
-  }
+  },
+  "packageManager": "pnpm@7.16.1"
 }


### PR DESCRIPTION
It would be beneficial to enable `corepack` and specify package manager version.
Doing so, `pnpm` can be prevented from generating diffs in the lock file due to version difference.

Another point is that enabling `corepack` can make this repository align with `unjs/template`.

TBH, I'm not sure if this change affect on Cloudflare usage.
If any, please close it.