### PR TITLE
fix: remove extra margin in code block

### DIFF
--- a/pages/[name].vue
+++ b/pages/[name].vue
@@ -160,6 +160,10 @@ readme.value.html = readme.value.html.replace(/src="\./g, `src="https://raw.gith
     background: rgba(0, 0, 0, .05);
     padding: 1rem;
     margin-bottom: 1rem;
+
+    pre {
+      margin-bottom: 0;
+    }
   }
 
   code {


### PR DESCRIPTION
`.readme pre` selector is given default margin bottom, but it brings about extra space to code blocks.

**As-Is**

<img width="1010" alt="Screen Shot 2022-12-03 at 11 02 25" src="https://user-images.githubusercontent.com/16436160/205417264-26986268-b7c7-4a4f-9e9d-799f34422e3e.png">

**To-Be**

<img width="1010" alt="Screen Shot 2022-12-03 at 11 02 58" src="https://user-images.githubusercontent.com/16436160/205417289-eaffe009-8273-4d5c-bf2a-10b8ddc5af23.png">
