### PR TITLE
fix: catch clause

### DIFF
--- a/server/api/repos.ts
+++ b/server/api/repos.ts
@@ -15,7 +15,7 @@ const hiddenRepos = new Set([
 ])
 
 export default defineEventHandler(async () => {
-  const { repos } = await $fetch('https://ungh.cc/orgs/unjs/repos') as any
+  const { repos } = await $fetch('https://ungh.cc/orgs/unjs/repos').catch(() => ({ repos: [] })) as any
   return repos
     .filter((repo: any) => !hiddenRepos.has(repo.name))
     .sort((a: any, b: any) => b.stars - a.stars)


### PR DESCRIPTION
Navigating to unjs.io gives me `500: Cannot read properties of null (reading 'length')` at times - maybe because `ungh.cc` server is inaccessible (to my network at least) in some cases.

Just adding small catch so the site still displays