### PR TITLE
docs(h3, blog): update the validation example

### DIFF
--- a/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
+++ b/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
@@ -129,13 +129,15 @@ export default eventHandler<{ body: { name: string }; query: { id: string } }>(
 Two new utility functions, `getValidatedQuery(event, validator)` and `readValidatedBody(event, validator)`, facilitate integration with schema validators such as [zod](https://zod.dev/) for both runtime and type safety.
 
 ```ts
+import { z } from 'zod'
+
 const userSchema = z.object({
   name: z.string().default('Guest'),
-  email: z.email().required(),
+  email: z.string().email(),
 })
 
 export default defineEventHandler((event) => {
-  const user = await readValidatedBody(event, userSchema.parse)
+  const user = await readValidatedBody(event, userSchema.safeParse)
   // User object is validated and typed!
   return {
     user

--- a/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
+++ b/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
@@ -137,7 +137,7 @@ const userSchema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
-  const user = await readValidatedBody(event, userSchema.safeParse)
+  const user = await readValidatedBody(event, userSchema.safeParse) // or `.parse` to throw an error
   // User object is validated and typed!
   return user
 })

--- a/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
+++ b/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
@@ -136,12 +136,10 @@ const userSchema = z.object({
   email: z.string().email(),
 })
 
-export default defineEventHandler((event) => {
+export default defineEventHandler(async (event) => {
   const user = await readValidatedBody(event, userSchema.safeParse)
   // User object is validated and typed!
-  return {
-    user
-  }
+  return user
 })
 ```
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

There were several fatal errors in the validation example.

- missing `async`
- `z.email()` does not exist. Changed to: `z.string().email()`. Source: https://zod.dev/?id=strings
- `.required()` works only for schema. Object entry always is required if `.optional()` not provided. Source: https://zod.dev/?id=required
- `.parse` returns errors in a form that is not easily readable. Better to use: `.safeParse`. Source: https://zod.dev/?id=safeparse

Examples of a verse from the API before and after the changes.

## Before:
### Error
```
{"url":"/api/test","statusCode":400,"statusMessage":"","message":"[\n  {\n    \"code\": \"invalid_type\",\n    \"expected\": \"object\",\n    \"received\": \"undefined\",\n    \"path\": [],\n    \"message\": \"Required\"\n  }\n]","stack":"<pre><span class=\"stack internal\">at createError (./node_modules/.pnpm/h3@1.8.0/node_modules/h3/dist/index.mjs:61:15)</span>\n<span class=\"stack internal\">at createValidationError (./node_modules/.pnpm/h3@1.8.0/node_modules/h3/dist/index.mjs:227:9)</span>\n<span class=\"stack internal\">at validateData (./node_modules/.pnpm/h3@1.8.0/node_modules/h3/dist/index.mjs:223:11)</span>\n<span class=\"stack internal\">at readValidatedBody (./node_modules/.pnpm/h3@1.8.0/node_modules/h3/dist/index.mjs:425:10)</span>\n<span class=\"stack internal\">at process.processTicksAndRejections (node:internal/process/task_queues:95:5)</span>\n<span class=\"stack\">at async ./.nuxt/dev/index.mjs:1561:16</span>\n<span class=\"stack internal\">at async Object.handler (./node_modules/.pnpm/h3@1.8.0/node_modules/h3/dist/index.mjs:1683:19)</span>\n<span class=\"stack internal\">at async Server.toNodeHandle (./node_modules/.pnpm/h3@1.8.0/node_modules/h3/dist/index.mjs:1893:7)</span></pre>"}
```

### Success
```
{
  "user": {
    "name": "Guest",
    "email": "unjs@unjs.io"
  }
}
```

## After
### Error
```
{
  "success": false,
  "error": {
    "issues": [
      {
        "code": "invalid_type",
        "expected": "object",
        "received": "undefined",
        "path": [],
        "message": "Required"
      }
    ],
    "name": "ZodError"
  }
}
```

### Success
```
{
  "success": true,
  "data": {
    "name": "Guest",
    "email": "unjs@unjs.io"
  }
}
```