### PR TITLE
feat: add release tag to nitro 2.6 blog

### DIFF
--- a/content/5.blog/2023-08-25-nitro-2.6.md
+++ b/content/5.blog/2023-08-25-nitro-2.6.md
@@ -10,6 +10,7 @@ authors:
     twitter: _pi0_
 categories:
   - nitro
+  - release
 packages:
   - nitro
 publishedAt: 2023-08-25


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

fix #74

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since the h3 blog post is labelled with a release tag, the nitro@2.6 must also have one.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
