### PR TITLE
fix: remove search from payload

### DIFF
--- a/components/app/AppSearchDialog.vue
+++ b/components/app/AppSearchDialog.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { Combobox, Dialog, DialogPanel, TransitionChild, TransitionRoot } from '@headlessui/vue'
-import type { SearchDisplayItem } from 'types/search'
 import AppSearchInput from './search/AppSearchInput.vue'
+import type { SearchDisplayItem } from '~/types/search'
 
 defineProps<{
   open: boolean
@@ -15,7 +15,7 @@ const selected = ref<SearchDisplayItem | null>(null)
 const query = ref('')
 
 const queryDebounced = refDebounced(query, 100)
-const results = await useSearchResults(queryDebounced)
+const results = await useSearchResults(queryDebounced, { lazy: true, server: false }) // Options to avoid to add `/api/search.txt` to the payload
 
 const defaultOptions = await useSearchDefaultResults()
 

--- a/composables/useSearch.ts
+++ b/composables/useSearch.ts
@@ -2,7 +2,7 @@ import MiniSearch, { type Options as MiniSearchOptions } from 'minisearch'
 import type { SearchDisplay, SearchDisplayItem, SearchResult } from '~/types/search'
 
 export async function useSearchDefaultResults(): Promise<ComputedRef<SearchDisplay>> {
-  const { data: packages } = await useAsyncData('packages', () => queryContent('/packages/').only(['title', '_path']).find())
+  const { data: packages } = await useAsyncData('content:search:packages', () => queryContent('/packages/').only(['title', '_path']).find())
 
   return computed(() => {
     if (!packages.value)

--- a/composables/useSearch.ts
+++ b/composables/useSearch.ts
@@ -1,8 +1,8 @@
 import MiniSearch, { type Options as MiniSearchOptions } from 'minisearch'
-import type { SearchDisplay, SearchDisplayItem, SearchResult } from 'types/search'
+import type { SearchDisplay, SearchDisplayItem, SearchResult } from '~/types/search'
 
 export async function useSearchDefaultResults(): Promise<ComputedRef<SearchDisplay>> {
-  const { data: packages } = await useAsyncData('packages', () => queryContent('/packages/').find())
+  const { data: packages } = await useAsyncData('packages', () => queryContent('/packages/').only(['title', '_path']).find())
 
   return computed(() => {
     if (!packages.value)
@@ -27,9 +27,9 @@ export async function useSearchDefaultResults(): Promise<ComputedRef<SearchDispl
   })
 }
 
-export async function useSearchResults(search: MaybeRefOrGetter<string>): Promise<ComputedRef<SearchDisplay>> {
+export async function useSearchResults(search: MaybeRefOrGetter<string>, options: { lazy?: boolean; server?: boolean } = {}): Promise<ComputedRef<SearchDisplay>> {
   const website = useWebsite()
-  const searchResults = await useSearch(search)
+  const searchResults = await useSearch(search, options)
 
   return computed(() => {
     if (!searchResults.value)
@@ -74,27 +74,29 @@ export async function useSearchResults(search: MaybeRefOrGetter<string>): Promis
   })
 }
 
-export async function useSearch(search: MaybeRefOrGetter<string>): Promise<ComputedRef<SearchResult[]>> {
-  const { data } = await useFetch<string>('/api/search.txt')
+export async function useSearch(search: MaybeRefOrGetter<string>, options: { lazy?: boolean; server?: boolean } = {}): Promise<ComputedRef<SearchResult[]>> {
+  const { data } = await useFetch<string>('/api/search.txt', options)
 
-  if (!data.value)
-    return computed(() => [])
+  return computed(() => {
+    if (!data.value)
+      return [] as SearchResult[]
 
-  const { results } = useIndexedMiniSearch(search, data as Ref<string>, {
-    fields: ['title', 'titles', 'text'],
-    storeFields: ['title', 'titles', 'text', 'level'],
-    searchOptions: {
-      prefix: true,
-      fuzzy: 0.2,
-      boost: {
-        title: 4,
-        text: 2,
-        titles: 1,
+    const { results } = useIndexedMiniSearch(search, data as Ref<string>, {
+      fields: ['title', 'titles', 'text'],
+      storeFields: ['title', 'titles', 'text', 'level'],
+      searchOptions: {
+        prefix: true,
+        fuzzy: 0.2,
+        boost: {
+          title: 4,
+          text: 2,
+          titles: 1,
+        },
       },
-    },
-  })
+    })
 
-  return results
+    return results.value
+  })
 }
 
 function useIndexedMiniSearch(search: MaybeRefOrGetter<string>, indexedData: MaybeRefOrGetter<string>, options: MiniSearchOptions) {

--- a/layouts/packages.vue
+++ b/layouts/packages.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const { data: packages } = await useAsyncData('packages', () => queryContent('/packages/').find())
+const { data: packages } = await useAsyncData('content:packages', () => queryContent('/packages/').find())
 </script>
 
 <template>

--- a/layouts/search.vue
+++ b/layouts/search.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { Combobox } from '@headlessui/vue'
-import type { SearchDisplayItem } from 'types/search'
+import type { SearchDisplayItem } from '~/types/search'
 
 const route = useRoute()
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) plus `content` type
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
fix #132

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 📰 Content (a new article or a change in the content folder)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
By moving away the `/api/search.txt` and filtering field from the `packages`, `payload` from `/` is reduced from `97kb` to `8kb`.

https://unjs.io/_payload.json vs https://feat-lazy-load-minisearch.unjs.pages.dev/_payload.json

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
