### PR TITLE
content: fix example in h3 towards the edge of the web blog post

### DIFF
--- a/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
+++ b/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
@@ -137,7 +137,7 @@ const userSchema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
-  const result = await readValidatedBody(event, userSchema.safeParse) // or `.parse` to directly throw an error
+  const result = await readValidatedBody(event, body => userSchema.safeParse(body).data) // or `.parse` to directly throw an error
 
   if (!result.success) {
      throw result.error.issues;

--- a/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
+++ b/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
@@ -137,9 +137,14 @@ const userSchema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
-  const user = await readValidatedBody(event, userSchema.safeParse) // or `.parse` to throw an error
+  const result = await readValidatedBody(event, userSchema.safeParse) // or `.parse` to throw an error
+
+  if (!result.success) {
+     throw result.issues;
+  }
+  
   // User object is validated and typed!
-  return user
+  return result.data
 })
 ```
 

--- a/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
+++ b/content/5.blog/2023-08-15-h3-towards-the-edge-of-the-web.md
@@ -137,10 +137,10 @@ const userSchema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
-  const result = await readValidatedBody(event, userSchema.safeParse) // or `.parse` to throw an error
+  const result = await readValidatedBody(event, userSchema.safeParse) // or `.parse` to directly throw an error
 
   if (!result.success) {
-     throw result.issues;
+     throw result.error.issues;
   }
   
   // User object is validated and typed!


### PR DESCRIPTION
`safeParse` is not returning the user validated object directly. Therefor I made the example a bit more clear.

Side note: It would be AMAZING if this two functions to validate the body and the query would also be part of Nuxt docs (and maybe Nitro docs aswell).

### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 📰 Content (a new article or a change in the content folder)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
