### PR TITLE
fix: fix typo in nuxt config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -90,6 +90,6 @@ export default defineNuxtConfig({
     ...packagesRedirects as NitroConfig['routeRules'],
   },
   devtools: {
-    enable: true,
+    enabled: true,
   },
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) plus `content` type
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 📰 Content (a new article or a change in the content folder)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR corrects a typo for the `devtools` option.