### PR TITLE
fix: responsiveness of HomeHeroEyeBrow component

### DIFF
--- a/components/home/HomeHeroEyeBrow.vue
+++ b/components/home/HomeHeroEyeBrow.vue
@@ -7,7 +7,7 @@ defineProps<{
 </script>
 
 <template>
-  <NuxtLink :to="`${path}?utm_source=unjs.io&utm_medium=home-hero`" class="group flex items-center gap-4">
+  <NuxtLink :to="`${path}?utm_source=unjs.io&utm_medium=home-hero`" class="group flex flex-wrap items-center justify-center gap-4">
     <span class="px-3 py-1 bg-primary/20 group-hover:bg-primary/25 dark:bg-primary/20 dark:group-hover:bg-primary/25 ring-1 ring-primary/90 dark:ring-primary/70 rounded-full text-sm text-gray-950 dark:text-gray-50 nowrap font-medium transition ease-in">
       {{ prefix }}
     </span>


### PR DESCRIPTION
### 🔗 Linked issue
No liked issue. 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 📰 Content (a new article or a change in the content folder)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Fixed the issue where announcement section (HomeHeroEyeBrow component) was wrapping the text leading to weird UI as shown below.
![image](https://github.com/unjs/website/assets/22255990/69fed8e9-f5b4-4c16-b5ff-a239374b36ec)

After fix:
![image](https://github.com/unjs/website/assets/22255990/ef890ca2-48f4-4183-a2d2-cf0bb5779af2)


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
