### PR TITLE
feat: add Bluesky account link on footer

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -160,6 +160,13 @@ export default defineAppConfig({
         icon: 'i-simple-icons-github',
         name: 'GitHub',
       },
+      bluesky: {
+        url: 'https://bsky.app/profile/unjs.io',
+        icon: 'i-simple-icons-bluesky',
+        rel: 'noopener',
+        target: '_blank',
+        name: 'Bluesky',
+      },
       x: {
         url: 'https://x.com/unjsio',
         icon: 'i-simple-icons-x',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -93,6 +93,7 @@ export default defineNuxtConfig({
       logo: 'https://unjs.io/favicon.svg',
       sameAs: [
         'https://github.com/unjs',
+        'https://bsky.app/profile/unjs.io',
         'https://twitter.com/unjsio',
       ],
     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) plus `content` type
-->

### 🔗 Linked issue

resolve #345

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 📰 Content (a new article or a change in the content folder)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
As written in the original issue, not having a Bluesky link makes it a bit difficult for new users to find a Bluesky account.

This PR adds two changes:
- add Bluesky account icon link on the footer
- adjust LD+JSON for the website to include Bluesky account profile

This helps new users find an account in an open platform where anyone who has Internet access can see the latest posts, unlike the other closed social media.

![Screenshot of footer, which has new Bluesky icon](https://github.com/user-attachments/assets/58b172b5-27b6-45e9-a5ce-46a939e05aef)
(with new Bluesky link icon)

![Screenshot of footer, which has new Bluesky icon](https://github.com/user-attachments/assets/a25007a7-a75a-48f0-907f-aae9a47e65f2)
(when hovering the mouse cursor)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
  - N/A for docs