### PR TITLE
chore: fix lint error

### DIFF
--- a/components/app/AppAlert.vue
+++ b/components/app/AppAlert.vue
@@ -22,6 +22,8 @@ const icon = computed(() => {
       return 'i-ph-warning'
     case 'Caution':
       return 'i-ph-warning-octagon'
+    default:
+      return undefined
   }
 })
 

--- a/components/learn/LearnCard.vue
+++ b/components/learn/LearnCard.vue
@@ -16,6 +16,8 @@ const categoryName = computed(() => {
       return 'Getting Started'
     case 'building-blocks':
       return 'Building Blocks'
+    default:
+      return undefined
   }
 })
 </script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) plus `content` type
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
N/A (see #345)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 📰 Content (a new article or a change in the content folder)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This PR fixes the lint error on the `main` branch. The previous GitHub Actions log was removed now, but it I found out there were only two simple lint errors.

The error of `pnpm run lint` fixed:

```shell
$ pnpm run lint

> website@ lint /home/shuuji3/dev/unjs-website
> eslint .

(node:1034756) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)

/home/shuuji3/dev/unjs-website/components/app/AppAlert.vue
  10:23  error  Expected to return a value in computed function  vue/return-in-computed-property

/home/shuuji3/dev/unjs-website/components/learn/LearnCard.vue
  13:31  error  Expected to return a value in computed function  vue/return-in-computed-property

✖ 2 problems (2 errors, 0 warnings)

 ELIFECYCLE  Command failed with exit code 1.

```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
  - N/A - no need to modify documentation for this lint fix.
