### PR TITLE
fix: allow partial match for package title

### DIFF
--- a/composables/usePackages.ts
+++ b/composables/usePackages.ts
@@ -10,7 +10,12 @@ export function usePackages() {
     idField: 'title',
     fields: ['title', 'description'],
     storeFields: fields,
+    processTerm: (term, fieldName) =>
+      fieldName === 'title'
+        ? suffixes(term, 1)
+        : MiniSearch.getDefault('processTerm')(term, fieldName),
     searchOptions: {
+      processTerm: MiniSearch.getDefault('processTerm'),
       prefix: true,
       fuzzy: 0.4,
       boost: {
@@ -168,4 +173,24 @@ export function usePackages() {
     numberOfPackages,
     monthlyDownloads,
   }
+}
+
+/**
+ * Split the given term into array of suffixes.
+ *
+ * @example
+ * suffixes('12345', 2)
+ * // => ['12345', '2345, '345', '45']
+ */
+function suffixes(term: string, minLength: number) {
+  if (term == null)
+    return
+
+  const tokens = []
+
+  for (let i = 0; i <= term.length - minLength; i++) {
+    tokens.push(term.slice(i).toLowerCase())
+  }
+
+  return tokens
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) plus `content` type
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
fix #197 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 📰 Content (a new article or a change in the content folder)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Currently, we are using the default `processTerm` logic with `prefix` option in minisearch, which only allows the prefix-search for the title of the packages.

I modified the processing operation only for the `title` field of the package during search index construction so that the partial keyword in the middle of the package name can be searched.

I used the example code in the GitHub comment (https://github.com/lucaong/minisearch/issues/194#issuecomment-1369229601) referred by the original issue #197.

![screenshot of search page, showing 7 packages with keyword "x"](https://github.com/user-attachments/assets/f73d520d-6bcd-45ea-b04d-00682515f4e2)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
  - N/A - this change does not affect the documentation.
